### PR TITLE
Fix for maven warning, pom.version --> project.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -561,7 +561,7 @@
         <profile>
             <id>build</id>
             <properties>
-                <isacreator.version>${pom.version}</isacreator.version>
+                <isacreator.version>${project.version}</isacreator.version>
                 <isacreator.alwaysShowInvestigation>false</isacreator.alwaysShowInvestigation>
             </properties>
 


### PR DESCRIPTION
Fix for the following Maven warning:

``` bash
$ mvn install
[INFO] Scanning for projects...
...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.isatools:ISAcreator:bundle:1.7.7
[WARNING] The expression ${pom.version} is deprecated. Please use ${project.version} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```
